### PR TITLE
Missing `bs4` in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 lxml
 fake_useragent
+bs4


### PR DESCRIPTION
I think `bs4` is missing in `requirement.txt`